### PR TITLE
class.mathjax.plugin.php: Fix quoting so all parens don't trigger math

### DIFF
--- a/class.mathjax.plugin.php
+++ b/class.mathjax.plugin.php
@@ -27,7 +27,7 @@ class MathJaxPlugin extends Gdn_Plugin {
             <script>
             MathJax.Hub.Config({
                 tex2jax: {
-                    inlineMath: [ ['[math]','[/math]'], ['\\(','\\)'] ]
+                    inlineMath: [ ['[math]','[/math]'], ['\\\\(','\\\\)'] ]
                 }
             });
         </script>


### PR DESCRIPTION
PHP itself interprets \ in the heredoc, so add extra quoting so that '\\('
ends up in the javascript. Otherwise '\(' is interpreted as a plain
parenthesis and all parenthesized words on the forum become math equations.